### PR TITLE
LIBFCREPO-125. Added clientcert script.

### DIFF
--- a/bin/clientcert
+++ b/bin/clientcert
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CN=${1:-fcrepolocal-client}
+FILENAME=${2:-$CN}
+
+# create client cert
+openssl req -new -nodes -newkey rsa:2048 -keyout "${FILENAME}.key" -subj "/CN=${CN}" \
+    | vagrant ssh fcrepo -- /apps/fedora/scripts/signcsr \
+    > "${FILENAME}.pem"


### PR DESCRIPTION
Creates a client cert signed by the vagrant box's CA. Takes a CN and file basename as arguments. If no file basename is given, it defaults to the same as the CN. If no CN is given, it defaults to "fcrepolocal-client".

https://issues.umd.edu/browse/LIBFCREPO-125
