### PR TITLE
LIBFCREPO-142. Set Karaf's fcrepo server to fcrepolocal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ the Fedora 4 application server running Tomcat, Karaf, and Fuseki.
     ```
 
 2. Clone [fcrepo-env] into
-   `/apps/git/fcrepo-env`, and check out the `vagrant` branch:
+   `/apps/git/fcrepo-env`, and check out the `develop` branch:
    
     ```
-    git clone git@github.com:umd-lib/fcrepo-env.git -b vagrant
+    git clone git@github.com:umd-lib/fcrepo-env.git -b develop
     ```
 
 3. Build an fcrepo.war webapp and place it in the [dist/fcrepo](dist/fcrepo) 
@@ -73,7 +73,7 @@ You should start solr manually anytime you restart the VM.
 ```
 vagrant ssh solr
 cd /apps/solr/example
-java -jar start.jar >> solr.log &
+nohup java -jar start.jar >> solr.log &
 ```
 
 ### Restoring Repository Data

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,6 +102,8 @@ Vagrant.configure(2) do |config|
     # create self-signed certificate for Apache
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/https-cert.sh"
 
+    # Add server-specific environment config
+    fcrepo.vm.provision "file", source: 'files/fcrepo/env', destination: '/apps/fedora/config/env'
     # Add custom transformation and configure solr indexing to use it
     fcrepo.vm.provision "file", source: 'files/fcrepo/custom-container-transformation.txt', destination: '/apps/fedora/config/custom-container-transformation.txt'
     fcrepo.vm.provision "file", source: 'files/fcrepo/custom-binary-transformation.txt', destination: '/apps/fedora/config/custom-binary-transformation.txt'

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -1,16 +1,14 @@
 # # vim:ft=sh
+export IP_ADDRESS=192.168.40.10
+export SERVER_NAME=fcrepolocal
 # Apache
-export LISTEN_IP=192.168.40.10
-export VIRTUAL_HOST_IP=$LISTEN_IP
-export SERVER_FQDN=fcrepolocal
 export SSL_CERT_NAME=fcrepolocal
 export SSL_KEY_NAME=fcrepolocal
 export TOMCAT_PROXY=https://localhost:9601
-export FUSEKI_PROXY=http://$LISTEN_IP:3030
+export FUSEKI_PROXY=http://localhost:3030
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
 # Tomcat
-export PROXY_NAME=fcrepolocal
 export KEY_ALIAS=fcrepolocal
 export PG_HOSTNAME=192.168.40.12
 export PG_USERNAME=fcrepo

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -1,0 +1,21 @@
+# # vim:ft=sh
+# Apache
+export LISTEN_IP=192.168.40.10
+export VIRTUAL_HOST_IP=$LISTEN_IP
+export SERVER_FQDN=fcrepolocal
+export SSL_CERT_NAME=fcrepolocal
+export SSL_KEY_NAME=fcrepolocal
+export TOMCAT_PROXY=https://localhost:9601
+export FUSEKI_PROXY=http://$LISTEN_IP:3030
+export SERVICE_USER=vagrant
+export SERVICE_GROUP=vagrant
+# Tomcat
+export PROXY_NAME=fcrepolocal
+export KEY_ALIAS=fcrepolocal
+export PG_HOSTNAME=192.168.40.12
+export PG_USERNAME=fcrepo
+export PG_PASSWORD=fcrepo
+# Karaf
+export FCREPO_SERVER=localhost:9601
+export SOLR_SERVER=solrlocal:8984
+export FUSEKI_SERVER=localhost:3030

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -14,6 +14,6 @@ export PG_HOSTNAME=192.168.40.12
 export PG_USERNAME=fcrepo
 export PG_PASSWORD=fcrepo
 # Karaf
-export FCREPO_SERVER=localhost:9601
+export FCREPO_SERVER=fcrepolocal
 export SOLR_SERVER=solrlocal:8984
 export FUSEKI_SERVER=localhost:3030

--- a/scripts/fcrepo/apache.sh
+++ b/scripts/fcrepo/apache.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-SERVICE_USER_GROUP=vagrant:vagrant
+SERVICE_USER=vagrant
+SERVICE_GROUP=vagrant
 
 # runtime environment
 mkdir -p /apps/fedora/apache/{bin,logs,run}
 mkdir -p /apps/fedora/apache/tmp/cas
-chown -R "$SERVICE_USER_GROUP" /apps/fedora/apache
+chown -R "${SERVICE_USER}:${SERVICE_GROUP}" /apps/fedora/apache
 
 # symlink to system modules
 ln -sf /usr/lib64/httpd/modules /apps/fedora/apache/modules
 
 # compile the helper setuid program
+rm /apps/fedora/apache/src/apachectl
 cp /usr/sbin/apachectl /apps/fedora/apache/bin/apachectl.exec
 sudo chown root:root /apps/fedora/apache/bin/apachectl.exec
 cd /apps/fedora/apache/src
-make SERVICE_USER=vagrant SERVICE_GROUP=vagrant install
+make SERVICE_USER="$SERVICE_USER" SERVICE_GROUP="$SERVICE_GROUP" install


### PR DESCRIPTION
This forces communication with fcrepo to go through the Apache reverse proxy, so all the fcrepo URLs that Karaf sees are external (i.e., hostname fcrpeolocal).

https://issues.umd.edu/browse/LIBFCREPO-142

Depends on #8 
