### PR TITLE
LIBFCREPO-122. Create bootstrap content as last step of provisioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ cd /apps/solr/example
 nohup java -jar start.jar >> solr.log &
 ```
 
-
 #### Start Fedora
 ```
 vagrant ssh fcrepo
 cd /apps/fedora
 ./control start
+```
+
+### Bootstrap Repository Data
+
+By default, the last step of provisioning the fcrepo machine creates a skeleton
+of bootstrap content in the repository (top level containers and minimal ACLs to
+support testing and interaction with the IIIF server). You can disable this step
+to start from an empty repository by setting the environment variable `EMPTY_REPO`
+before starting the Vagrant:
+
+```
+EMPTY_REPO=1 vagrant up
 ```
 
 ### Restoring Repository Data

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,6 @@ Vagrant.configure(2) do |config|
 
     # Add server-specific environment config
     fcrepo.vm.provision "file", source: 'files/fcrepo/env', destination: '/apps/fedora/config/env'
-    fcrepo.vm.provision "file", source: 'files/fcrepo/add-iiif-acl.sh', destination: '/apps/fedora/scripts/add-iiif-acl.sh'
 
     # Create SSL CA and client certificates
     fcrepo.vm.provision "shell", inline: "cd /apps/fedora/scripts && ./sslsetup.sh", privileged: false
@@ -112,9 +111,10 @@ Vagrant.configure(2) do |config|
     # Start the applications
     fcrepo.vm.provision "shell", inline: "cd /apps/fedora && ./control start", privileged: false
 
-    # Bootstrap the ACLs for the iiif server user
-    # TODO: broaden this to a generic bootstrapping (see https://issues.umd.edu/browse/LIBFCREPO-122)
-    fcrepo.vm.provision "shell", inline: "cd /apps/fedora/scripts && ./add-iiif-acl.sh", privileged: false
+    unless ENV['EMPTY_REPO']
+      # Bootstrap the top-level collections and ACLs
+      fcrepo.vm.provision "shell", inline: "cd /apps/fedora/scripts/bootstrap && ./bootstrap-repo.sh", privileged: false
+    end
 
   end
 end


### PR DESCRIPTION
Unless the environment variable "EMPTY_REPO" is set, create bootstrap content as the last step of provisioning the fcrepo machine.

https://issue.umd.edu/browse/LIBFCREPO-122