### PR TITLE
LIBFCREPO-178. Provision the environment with git clone.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,12 @@ Vagrant.configure(2) do |config|
     # system provisioning
     fcrepo.vm.provision "puppet", manifest_file: 'fcrepo.pp', environment: 'local'
 
+    # configure Git
+    fcrepo.vm.provision 'shell', path: 'scripts/fcrepo/git.sh', args: [`git config user.name`, `git config user.email`],
+      privileged: false
+    # install runtime env
+    fcrepo.vm.provision "shell", path: "scripts/fcrepo/env.sh"
+
     # copy the default vagrant key so we can easily ssh between fcrepo and solr boxes
     # this works because this base box adds the insecure public key to the vagrant
     # user's authorized_hosts file
@@ -100,8 +106,6 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/karaf.sh"
     # install Fuseki
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/fuseki.sh"
-    # install runtime env
-    fcrepo.vm.provision "shell", path: "scripts/fcrepo/env.sh"
     # deploy webapps
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/webapps.sh", privileged: false
     # configure Apache runtime

--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -35,6 +35,9 @@ package { 'jq':
 package { 'nc':
   ensure => present,
 }
+package { 'git':
+  ensure => present,
+}
 
 host { 'fcrepolocal':
   ip => '192.168.40.10',

--- a/scripts/fcrepo/apache.sh
+++ b/scripts/fcrepo/apache.sh
@@ -16,4 +16,4 @@ rm /apps/fedora/apache/src/apachectl
 cp /usr/sbin/apachectl /apps/fedora/apache/bin/apachectl.exec
 sudo chown root:root /apps/fedora/apache/bin/apachectl.exec
 cd /apps/fedora/apache/src
-make SERVICE_USER="$SERVICE_USER" SERVICE_GROUP="$SERVICE_GROUP" install
+make SERVICE_USER="$SERVICE_USER" SERVICE_GROUP="$SERVICE_GROUP" install clean

--- a/scripts/fcrepo/env.sh
+++ b/scripts/fcrepo/env.sh
@@ -5,5 +5,5 @@ SERVICE_USER_GROUP=vagrant:vagrant
 ENV_SRC_DIR=/apps/git/fcrepo-env
 ENV_TARGET_DIR=/apps/fedora
 
-cp -rp "$ENV_SRC_DIR"/* "$ENV_TARGET_DIR"
+git clone "file://$ENV_SRC_DIR/.git" "$ENV_TARGET_DIR"
 chown -R "$SERVICE_USER_GROUP" "$ENV_TARGET_DIR"

--- a/scripts/fcrepo/git.sh
+++ b/scripts/fcrepo/git.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NAME=$1
+EMAIL=$2
+
+git config --global user.name "$NAME"
+git config --global user.email "$EMAIL"
+git config --global color.ui true

--- a/scripts/fcrepo/karaf.sh
+++ b/scripts/fcrepo/karaf.sh
@@ -12,31 +12,7 @@ if [ ! -e "$KARAF_TGZ" ]; then
 fi
 KARAF_HOME=/apps/fedora/karaf
 mkdir -p "$KARAF_HOME"
-tar xvzf "$KARAF_TGZ" --directory "$KARAF_HOME" --strip-components 1
+# exclude the /etc directory, since we have our own customizations in the fcrepo-env
+tar xvzf "$KARAF_TGZ" --directory "$KARAF_HOME" --strip-components 1 --exclude etc
 
 chown -R "$SERVICE_USER_GROUP" "$KARAF_HOME"
-
-### setting up /apps/fedora/karaf
-#mkdir -p /apps/fedora/karaf/etc
-#cp -rp "$KARAF_HOME/etc" /apps/fedora/karaf
-#mkdir -p /apps/fedora/karaf/data
-#chown -R "$SERVICE_USER_GROUP" /apps/fedora/karaf
-
-
-### fcrepo camel setup (https://wiki.duraspace.org/display/FEDORA4x/Setup+Camel+Message+Integrations)
-#sudo -u vagrant "$KARAF_HOME/bin/karaf" -f - <<END
-#feature:repo-add camel 2.14.0
-#feature:repo-add activemq 5.10.0
-#feature:install camel
-#feature:install activemq-camel
-#
-## display available camel features
-#feature:list | grep camel
-#
-## install camel features, as needed
-#feature:install camel-http4
-#
-## install fcrepo-camel (as of v4.1.0)
-#feature:repo-add mvn:org.fcrepo.camel/fcrepo-camel/LATEST/xml/features
-#feature:install fcrepo-camel
-#END


### PR DESCRIPTION
* Installs an configures git with the name and email of the user running the "vagrant up" process.
* Clones the environment from the "file:///apps/git/fcrepo-env/.git" repo that is mounted as a shared folder. The active branch in the host's repo becomes the checked out branch in the Vagrant repo.
* Skips extracting the "etc" directory from the Karaf tarball to avoid clobbering our customized Karaf environment.
* Include "make clean" when building the apachectl setuid script, to avoid having the unversioned binary hanging around in the "apache/src" directory.

https://issues.umd.edu/browse/LIBFCREPO-178