### PR TITLE
Remove "-SNAPSHOT" from the umd-fcrepo-webapp version.

### DIFF
--- a/scripts/fcrepo/artifacts.sh
+++ b/scripts/fcrepo/artifacts.sh
@@ -22,4 +22,4 @@ cd /apps/dist
 get_artifact releases edu.umd.lib optional-authn-valve 1.0.0 jar
 get_artifact releases edu.umd.lib header-to-cert-valve 1.0.0 jar
 get_artifact releases edu.umd.lib fcrepo-user-webapp 1.0.0 war
-get_artifact snapshots edu.umd.lib umd-fcrepo-webapp 1.0.0-SNAPSHOT war
+get_artifact releases edu.umd.lib umd-fcrepo-webapp 1.0.0 war

--- a/scripts/fcrepo/webapps.sh
+++ b/scripts/fcrepo/webapps.sh
@@ -3,4 +3,4 @@
 WEBAPP_DIR=/apps/fedora/webapps
 mkdir -p "$WEBAPP_DIR"
 cd /apps/dist
-cp umd-fcrepo-webapp-1.0.0-SNAPSHOT.war fcrepo-user-webapp-1.0.0.war "$WEBAPP_DIR"
+cp umd-fcrepo-webapp-1.0.0.war fcrepo-user-webapp-1.0.0.war "$WEBAPP_DIR"


### PR DESCRIPTION
@mohideen This parallels your hotfix to fcrepo-env to correct the name of the umd-fcrepo-webapp artifact.