### PR TITLE
LIBFCREPO-262. Provision with ActiveMQ 5.14.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Congratulations, you should now have a running fcrepo-vagrant!
 * Log in: <https://fcrepolocal/user>
 * Fedora REST interface: <https://fcrepolocal/fcrepo/rest>
 * Solr Admin interface: <https://solrlocal:8984/solr>
+* ActiveMQ Admin Interface: <http://fcrepolocal:8161/admin>
+  - Username/password: `admin`/`admin`
 
 ### Starting the application 
 
@@ -60,8 +62,8 @@ You should start solr and fedora manually anytime you restart the VM.
 #### Start Solr
 ```
 vagrant ssh solr
-cd /apps/solr
-bin/solr start
+cd /apps/solr/solr
+./control start
 ```
 
 #### Start Fedora
@@ -123,11 +125,11 @@ The Solr web server also uses a self-signed HTTPS certificate, cached in [dist/s
 
 ## VM Info
 
-|Box Name |Hostname   |IP Address   |OS        |Open Ports|
-|---------|-----------|-------------|----------|----------|
-|fcrepo   |fcrepolocal|192.168.40.10|CentOS 6.6|80,443 |
-|solr     |solrlocal  |192.168.40.11|CentOS 6.6|8983,8984 |
-|postgres |pglocal    |192.168.40.12|CentOS 6.6|5432      |
+|Box Name |Hostname   |IP Address   |OS        |Open Ports |
+|---------|-----------|-------------|----------|-----------|
+|fcrepo   |fcrepolocal|192.168.40.10|CentOS 6.6|80,443,8161|
+|solr     |solrlocal  |192.168.40.11|CentOS 6.6|8983,8984  |
+|postgres |pglocal    |192.168.40.12|CentOS 6.6|5432       |
 
 
 [Vagrantfile](Vagrantfile)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,6 +100,8 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/jdk.sh"
     # install Tomcat
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/tomcat.sh"
+    # install ActiveMQ
+    fcrepo.vm.provision "shell", path: "scripts/fcrepo/activemq.sh"
     # install Karaf
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/karaf.sh"
     # install Fuseki

--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -55,3 +55,8 @@ firewall { '100 allow http and https access':
   proto  => tcp,
   action => accept,
 }
+firewall { '150 ActiveMQ admin console webapp':
+  dport  => 8161,
+  proto  => tcp,
+  action => accept,
+}

--- a/scripts/fcrepo/activemq.sh
+++ b/scripts/fcrepo/activemq.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SERVICE_USER_GROUP=vagrant:vagrant
+
+# Activemq
+ACTIVEMQ_VERSION=5.14.3
+ACTIVEMQ_TGZ=/apps/dist/apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz
+# look for a cached tarball
+if [ ! -e "$ACTIVEMQ_TGZ" ]; then
+    ACTIVEMQ_PKG_URL=http://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz
+    curl -Lso "$ACTIVEMQ_TGZ" "$ACTIVEMQ_PKG_URL"
+fi
+tar xvzf "$ACTIVEMQ_TGZ" --directory /apps
+
+ACTIVEMQ_HOME=/apps/apache-activemq-${ACTIVEMQ_VERSION}
+# for some reason, ActiveMQ requires that its lib directory be owned by the
+# user who starts the ActiveMQ broker process
+chown -R "$SERVICE_USER_GROUP" "$ACTIVEMQ_HOME/lib"


### PR DESCRIPTION
Open port 8161 on the firewall so we can access the ActiveMQ webapp admin console. Updated README.

https://issues.umd.edu/browse/LIBFCREPO-262