### PR TITLE
LIBFCREPO-297. Close port 8161.

### DIFF
--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -55,8 +55,3 @@ firewall { '100 allow http and https access':
   proto  => tcp,
   action => accept,
 }
-firewall { '150 ActiveMQ admin console webapp':
-  dport  => 8161,
-  proto  => tcp,
-  action => accept,
-}


### PR DESCRIPTION
ActiveMQ console is available through reverse proxy on port 443.

https://issues.umd.edu/browse/LIBFCREPO-297