### PR TITLE
LIBFCREPO-367. Set puppetlabs-postgresql module version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
 
     postgres.vm.provision "shell", inline: <<-SHELL
       puppet module install puppetlabs-firewall
-      puppet module install puppetlabs-postgresql
+      puppet module install puppetlabs-postgresql --version 4.9.0
     SHELL
 
     postgres.vm.provision "puppet", manifest_file: 'postgres.pp', environment: 'local'


### PR DESCRIPTION
To ensure the Vagrant keeps working until we can upgrade, pin the module to the 4.9.0 release.

https://issues.umd.edu/browse/LIBFCREPO-367