### PR TITLE
LIBFCREPO-370. Install JMX on the Vagrant.

### DIFF
--- a/bin/clientcert
+++ b/bin/clientcert
@@ -7,3 +7,10 @@ FILENAME=${2:-$CN}
 openssl req -new -nodes -newkey rsa:2048 -keyout "${FILENAME}.key" -subj "/CN=${CN}" \
     | vagrant ssh fcrepo -- /apps/fedora/scripts/signcsr \
     > "${FILENAME}.pem"
+
+# convert to a Java JKS
+openssl pkcs12 -export -clcerts -in "${FILENAME}.pem" -inkey "${FILENAME}.key" \
+    -out "${FILENAME}.p12" -passout pass:changeme
+keytool -importkeystore \
+    -srckeystore "${FILENAME}.p12" -srcstoretype pkcs12 -srcstorepass changeme \
+    -destkeystore "${FILENAME}.jks" -deststoretype jks -deststorepass changeme

--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -63,3 +63,8 @@ firewall { '100 allow http and https access':
   proto  => tcp,
   action => accept,
 }
+firewall { '110 allow JMX remote access':
+  dport  => [10001, 10002],
+  proto  => tcp,
+  action => accept,
+}

--- a/scripts/fcrepo/tomcat.sh
+++ b/scripts/fcrepo/tomcat.sh
@@ -23,5 +23,12 @@ mkdir -p "$CATALINA_BASE"/{logs,temp}
 mkdir -p "$CATALINA_BASE/lib"
 cp /apps/dist/optional-authn-valve-*.jar "$CATALINA_BASE/lib"
 cp /apps/dist/header-to-cert-valve-*.jar "$CATALINA_BASE/lib"
+# get the JMX Remote Lifecycle Listener
+JMX_JAR=/apps/dist/catalina-jmx-remote.jar
+if [ ! -e "$JMX_JAR" ]; then
+    curl -Lso "$JMX_JAR" \
+        "https://archive.apache.org/dist/tomcat/tomcat-7/v${TOMCAT_VERSION}/bin/extras/catalina-jmx-remote.jar"
+fi
+cp /apps/dist/catalina-jmx-remote.jar "$CATALINA_BASE/lib"
 
 chown -R "$SERVICE_USER_GROUP" "$CATALINA_BASE"


### PR DESCRIPTION
Generate a JKS along with a PEM for client certs.

https://issues.umd.edu/browse/LIBFCREPO-370