### PR TITLE
LIBFCREPO-419. Updated artifact provisioning and umd-fcrepo-webapp version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,8 +98,6 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.provision "file",
       source: "#{ENV['HOME']}/.vagrant.d/insecure_private_key",
       destination: "/home/vagrant/.ssh/id_rsa"
-    # get pre-built artifacts (from Nexus)
-    fcrepo.vm.provision "shell", path: "scripts/fcrepo/artifacts.sh"
     # install JDK
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/jdk.sh"
     # install Tomcat
@@ -110,8 +108,8 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/karaf.sh"
     # install Fuseki
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/fuseki.sh"
-    # deploy webapps
-    fcrepo.vm.provision "shell", path: "scripts/fcrepo/webapps.sh", privileged: false
+    # deploy artifacts (JARs and WARs) from Nexus
+    fcrepo.vm.provision "shell", path: "scripts/fcrepo/artifacts.sh", privileged: false
     # configure Apache runtime
     fcrepo.vm.provision "shell", path: "scripts/fcrepo/apache.sh"
     # create self-signed certificate for Apache

--- a/scripts/fcrepo/artifacts.sh
+++ b/scripts/fcrepo/artifacts.sh
@@ -58,4 +58,4 @@ WEBAPP_DIR=/apps/fedora/webapps
 mkdir -p "$WEBAPP_DIR"
 cd "$WEBAPP_DIR"
 get_artifact -a fcrepo-user-webapp -v 1.1.0 -p war
-get_artifact -a umd-fcrepo-webapp -v 1.1.0 -p war
+get_artifact -a umd-fcrepo-webapp -v 1.2.0 -p war

--- a/scripts/fcrepo/tomcat.sh
+++ b/scripts/fcrepo/tomcat.sh
@@ -21,8 +21,6 @@ mkdir -p "$CATALINA_BASE"/{logs,temp}
 
 # local libs
 mkdir -p "$CATALINA_BASE/lib"
-cp /apps/dist/optional-authn-valve-*.jar "$CATALINA_BASE/lib"
-cp /apps/dist/header-to-cert-valve-*.jar "$CATALINA_BASE/lib"
 # get the JMX Remote Lifecycle Listener
 JMX_JAR=/apps/dist/catalina-jmx-remote.jar
 if [ ! -e "$JMX_JAR" ]; then

--- a/scripts/fcrepo/webapps.sh
+++ b/scripts/fcrepo/webapps.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-WEBAPP_DIR=/apps/fedora/webapps
-mkdir -p "$WEBAPP_DIR"
-cd /apps/dist
-
-cp umd-fcrepo-webapp-1.1.0.war fcrepo-user-webapp-1.1.0.war "$WEBAPP_DIR"


### PR DESCRIPTION
The artifacts script now runs as the unprivileged user, at the point in provisioning where web apps.sh used to run. It now downloads the JAR and WAR files directly to their final locations.

https://issues.umd.edu/browse/LIBFCREPO-419