### PR TITLE
LIBFCREPO-446. Added "puppetlabs-stdlib" dependency, pinned to v4.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Congratulations, you should now have a running fcrepo-vagrant!
 * Log in: <https://fcrepolocal/user>
 * Fedora REST interface: <https://fcrepolocal/fcrepo/rest>
 * Solr Admin interface: <https://solrlocal:8984/solr>
-* ActiveMQ Admin Interface: <http://fcrepolocal:8161/admin>
-  - Username/password: `admin`/`admin`
+* ActiveMQ Admin Interface: <https://fcrepolocal/activemq/admin>
+  - Should allow access, via CAS, for anyone having an LDAP "ou" beginning with "LIBR-"
 
 **Note:** See the "Troubleshooting" section if unable to access the Fedora REST interface after logging in.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,8 @@ Vagrant.configure(2) do |config|
     postgres.vm.network "private_network", ip: "192.168.40.12"
 
     postgres.vm.provision "shell", inline: <<-SHELL
+      # puppetlabs-stdlib is "pinned" to v4.22.0 for v4.9.0 of puppetlabs-postgresql
+      puppet module install puppetlabs-stdlib --version 4.22.0
       puppet module install puppetlabs-firewall
       puppet module install puppetlabs-postgresql --version 4.9.0
     SHELL
@@ -36,7 +38,11 @@ Vagrant.configure(2) do |config|
     solr.vm.synced_folder "/apps/git/fedora4-core", "/apps/git/fedora4-core"
 
     # Puppet Modules
-    solr.vm.provision "shell", inline: 'puppet module install puppetlabs-firewall'
+    solr.vm.provision "shell", inline: <<-SHELL
+      # puppetlabs-stdlib is "pinned" to v4.22.0 for "solr.pp"
+      puppet module install puppetlabs-stdlib --version 4.22.0
+      puppet module install puppetlabs-firewall
+    SHELL
 
     # system provisioning
     solr.vm.provision "puppet", manifest_file: 'solr.pp', environment: 'local'
@@ -82,7 +88,11 @@ Vagrant.configure(2) do |config|
     end
 
     # Puppet Modules
-    fcrepo.vm.provision "shell", inline: 'puppet module install puppetlabs-firewall'
+    fcrepo.vm.provision "shell", inline: <<-SHELL
+      # puppetlabs-stdlib is "pinned" to v4.22.0 for "fcrepo.pp"
+      puppet module install puppetlabs-stdlib --version 4.22.0
+      puppet module install puppetlabs-firewall
+    SHELL
 
     # system provisioning
     fcrepo.vm.provision "puppet", manifest_file: 'fcrepo.pp', environment: 'local'


### PR DESCRIPTION
Added "puppetlabs-stdlib" dependency and pinned it to v4.22.0, as
v4.23.0 contains changes that cause errors and break the Vagrant
build process.

Also updated README.md to update ActiveMQ Admin URL and credential information.

https://issues.umd.edu/browse/LIBFCREPO-446