### PR TITLE
LIBFCREPO-501. Update Nexus URL.

### DIFF
--- a/scripts/fcrepo/artifacts.sh
+++ b/scripts/fcrepo/artifacts.sh
@@ -40,8 +40,9 @@ function get_artifact {
     FILENAME=${FILENAME:-${ARTIFACT}-${VERSION}.${PACKAGING}}
 
     # now retrieve from Nexus
-    NEXUS_BASE_URL=https://maven.lib.umd.edu/nexus/service/local/artifact/maven/content
-    NEXUS_URL="$NEXUS_BASE_URL?r=$REPOSITORY&g=$GROUP&a=$ARTIFACT&v=$VERSION&p=$PACKAGING"
+    NEXUS_BASE_URL=https://maven.lib.umd.edu/nexus/repository
+    GROUP_PATH=$(tr '.' '/' <<<"$GROUP")
+    NEXUS_URL="$NEXUS_BASE_URL/$REPOSITORY/$GROUP_PATH/$ARTIFACT/$VERSION/$ARTIFACT-$VERSION.$PACKAGING"
 
     if [ ! -e "$FILENAME" ]; then
         curl -Lso "$FILENAME" "$NEXUS_URL"


### PR DESCRIPTION
With the upgrade to Nexus 3, the REST API URLs for downloading artifacts have changed. Updated the provisioning script to reflect this change.

https://issues.umd.edu/browse/LIBFCREPO-501