### PR TITLE
LIBFCREPO-567. Set roles via environment variables.

### DIFF
--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -14,7 +14,7 @@ export ACTIVEMQ_ADMIN_LDAP_ATTR=ou=LIBR-Libraries
 export KEY_ALIAS=fcrepolocal
 # set this to fedoraAdmin to give all directory authenticated users admin access
 # NOTE: this value should remain UNSET on PRODUCTION
-export LDAP_COMMON_ROLE=fedoraAdmin
+export LDAP_COMMON_ROLE=cn=Application_Roles:Libraries:FCREPO:FCREPO-Administrator,ou=grouper,ou=group,dc=umd,dc=edu
 export PG_HOSTNAME=192.168.40.12
 export PG_PORT=5432
 export PG_USERNAME=fcrepo

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -8,9 +8,13 @@ export TOMCAT_PROXY=https://localhost:9601
 export FUSEKI_PROXY=http://localhost:3030
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
+export FUSEKI_ADMIN_LDAP_ATTR=ou=LIBR-Libraries
+export ACTIVEMQ_ADMIN_LDAP_ATTR=ou=LIBR-Libraries
 # Tomcat
 export KEY_ALIAS=fcrepolocal
-export FEDORA_ADMIN_LDAP_FILTER='(uid={0})'
+# set this to fedoraAdmin to give all directory authenticated users admin access
+# NOTE: this value should remain UNSET on PRODUCTION
+export LDAP_COMMON_ROLE=fedoraAdmin
 export PG_HOSTNAME=192.168.40.12
 export PG_PORT=5432
 export PG_USERNAME=fcrepo


### PR DESCRIPTION
Set Fuseki and ActiveMQ admin roles to any LIBR user, and make all directory authenticated users fedoraAdmin for the Tomcat webapp.

https://issues.umd.edu/browse/LIBFCREPO-567