### PR TITLE
LIBFCREPO-388. Ensure /apps/fedora/webapps directory exists.

### DIFF
--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -75,7 +75,7 @@ file { ['/data', '/data/binaries']:
   group  => 'vagrant',
 }
 
-file { ['/apps/fedora', '/apps/fedora/logs']:
+file { ['/apps/fedora', '/apps/fedora/logs', '/apps/fedora/webapps']:
   ensure => directory,
   owner  => 'vagrant',
   group  => 'vagrant',


### PR DESCRIPTION
This needs to be done initially since the fcrepo-env no longer has a webapps directory.

https://issues.umd.edu/browse/LIBFCREPO-388