### PR TITLE
LIBFCREPO-621. Added a .curlrc dotfile to ~vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,6 +159,9 @@ Vagrant.configure(2) do |config|
     # pyenv and Python 3
     fcrepo.vm.provision 'shell', path: 'scripts/fcrepo/python.sh', privileged: false
 
+    # vagrant user dotfiles
+    fcrepo.vm.provision 'file', source: 'files/fcrepo/.curlrc', destination: '/home/vagrant/.curlrc'
+
     # Start the applications
     fcrepo.vm.provision "shell", inline: "cd /apps/fedora && ./control start", privileged: false, run: 'always'
 

--- a/files/fcrepo/.curlrc
+++ b/files/fcrepo/.curlrc
@@ -1,0 +1,2 @@
+# default to using the --insecure/-k flag on Vagrant
+insecure


### PR DESCRIPTION
Sets the --insecure/-k flag since we use self-signed certs in the Vagrant environment.

https://issues.umd.edu/browse/LIBFCREPO-621