### PR TITLE
LIBFCREPO-653. Ensue latest CA certs, NSS, and curl.

### DIFF
--- a/manifests/fcrepo.pp
+++ b/manifests/fcrepo.pp
@@ -2,8 +2,22 @@ Package {
   allow_virtual => false,
 }
 
+package { 'ca-certificates':
+  ensure => latest,
+}
+package { 'nss':
+  ensure => latest,
+}
+package { 'curl':
+  ensure => latest,
+}
 package { 'epel-release':
-  ensure => present,
+  ensure  => present,
+  require => [
+    Package['ca-certificates'],
+    Package['nss'],
+    Package['curl'],
+  ],
 }
 package { 'httpd':
   ensure => present,
@@ -37,9 +51,6 @@ package { 'nc':
 }
 package { 'git':
   ensure => present,
-}
-package { 'nss':
-  ensure => latest,
 }
 package { 'zlib-devel':
   ensure => latest,


### PR DESCRIPTION
Fixes SSL protocol errors when contacting the epel yum repo.

https://issues.umd.edu/browse/LIBFCREPO-653