### PR TITLE
LIBFCREPO-683. Configure fcrepo_audit database.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,12 @@ Vagrant.configure(2) do |config|
     SHELL
 
     postgres.vm.provision "puppet", manifest_file: 'postgres.pp', environment: 'local'
+
+    postgres.vm.provision 'file', source: 'files/postgres/pgpass', destination: '/home/vagrant/.pgpass'
+    postgres.vm.provision 'file', source: 'files/postgres/fcrepo_audit.sql', destination: '/home/vagrant/fcrepo_audit.sql'
+
+    # additional databases
+    postgres.vm.provision "shell", path: 'scripts/postgres/databases.sh', privileged: false
   end
 
   # Solr server

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -24,6 +24,9 @@ export PG_HOSTNAME=192.168.40.12
 export PG_PORT=5432
 export PG_USERNAME=fcrepo
 export PG_PASSWORD=fcrepo
+export PG_AUDIT_DATABASE=fcrepo_audit
+export PG_CAMEL_USERNAME=camel
+export PG_CAMEL_PASSWORD=camel
 # Karaf
 export FCREPO_SERVER=fcrepolocal
 export SOLR_SERVER=solrlocal:8984

--- a/files/postgres/fcrepo_audit.sql
+++ b/files/postgres/fcrepo_audit.sql
@@ -1,0 +1,15 @@
+-- tables
+
+CREATE TABLE history (
+    event_uri VARCHAR PRIMARY KEY,
+    event_type VARCHAR NOT NULL,
+    username VARCHAR NOT NULL,
+    resource_uri VARCHAR NOT NULL,
+    timestamp TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- users and permissions
+
+CREATE USER camel WITH PASSWORD 'camel';
+
+GRANT SELECT, INSERT ON history TO camel;

--- a/files/postgres/pgpass
+++ b/files/postgres/pgpass
@@ -1,0 +1,3 @@
+# hostname:port:database:username:password
+*:*:*:postgres:postgres
+*:*:fcrepo_audit:camel:camel

--- a/manifests/postgres.pp
+++ b/manifests/postgres.pp
@@ -32,6 +32,14 @@ postgresql::server::pg_hba_rule { 'fcrepo@192.168.40.0/24:fcrepo_modeshape5':
   address     => '192.168.40.0/24',
   auth_method => 'md5',
 }
+postgresql::server::pg_hba_rule { 'camel@192.168.40.0/24:fcrepo_audit':
+  description => "Open up fcrepo_audit database for access over the network by camel",
+  type        => 'host',
+  database    => 'fcrepo_audit',
+  user        => 'camel',
+  address     => '192.168.40.0/24',
+  auth_method => 'md5',
+}
 
 firewall { '100 allow access to PostgreSQL':
   dport => [5432],

--- a/scripts/postgres/databases.sh
+++ b/scripts/postgres/databases.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# ensure correct permissions on .pgpass
+chmod 600 $HOME/.pgpass
+
+createdb -U postgres -h localhost --no-password fcrepo_audit
+psql -U postgres -h localhost --no-password fcrepo_audit <$HOME/fcrepo_audit.sql


### PR DESCRIPTION
* Setup fcrepo_audit database with a user "camel" who has select and insert permissions
* Create a "history" table in the fcrepo_audit database
* Include a .pgpass file in ~vagrant so the provisioning scripts can create the database and table

https://issues.umd.edu/browse/LIBFCREPO-683