### PR TITLE
LIBFCREPO-698. Run Solr on http instead of https.

### DIFF
--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -11,8 +11,6 @@ export SSL_CERT_NAME=fcrepolocal
 export SSL_KEY_NAME=fcrepolocal
 export TOMCAT_PROXY=https://localhost:9601
 export FUSEKI_PROXY=http://localhost:3030
-export SERVICE_USER=vagrant
-export SERVICE_GROUP=vagrant
 export FUSEKI_ADMIN_LDAP_ATTR=ou=LIBR-Libraries
 export ACTIVEMQ_ADMIN_LDAP_ATTR=ou=LIBR-Libraries
 # Tomcat
@@ -29,7 +27,7 @@ export PG_CAMEL_USERNAME=camel
 export PG_CAMEL_PASSWORD=camel
 # Karaf
 export FCREPO_SERVER=fcrepolocal
-export SOLR_SERVER=solrlocal:8984
+export SOLR_URL=http://solrlocal:8983/solr/fedora4
 export FUSEKI_SERVER=fcrepolocal
 export KARAF_FCREPO_LOG_LEVEL=DEBUG
 export KARAF_LOG_RETENTION_DAYS=2

--- a/files/solr/control
+++ b/files/solr/control
@@ -4,11 +4,14 @@ export SOLR_INSTALL=/apps/solr-6.4.0
 export SOLR_HOME=/apps/solr/solr
 export SOLR_LOGS_DIR="$SOLR_HOME/logs"
 export SOLR_PID_DIR="$SOLR_HOME"
-export SOLR_PORT=8984
-export SOLR_SSL_KEY_STORE="$SOLR_HOME/solr-ssl.keystore.jks"
-export SOLR_SSL_KEY_STORE_PASSWORD=changeme
-export SOLR_SSL_TRUST_STORE="$SOLR_HOME/solr-ssl.keystore.jks"
-export SOLR_SSL_TRUST_STORE_PASSWORD=changeme
+
+function export_ssl_options {
+    export SOLR_PORT=8984
+    export SOLR_SSL_KEY_STORE="$SOLR_HOME/solr-ssl.keystore.jks"
+    export SOLR_SSL_KEY_STORE_PASSWORD=changeme
+    export SOLR_SSL_TRUST_STORE="$SOLR_HOME/solr-ssl.keystore.jks"
+    export SOLR_SSL_TRUST_STORE_PASSWORD=changeme
+}
 
 case "$1" in
     start)
@@ -17,6 +20,16 @@ case "$1" in
         ;;
     stop)
         cd "$SOLR_INSTALL"
+        bin/solr stop
+        ;;
+    startssl)
+        cd "$SOLR_INSTALL"
+        export_ssl_options
+        bin/solr start
+        ;;
+    stopssl)
+        cd "$SOLR_INSTALL"
+        export_ssl_options
         bin/solr stop
         ;;
     *)


### PR DESCRIPTION
* added startssl/stopssl commands to the Solr control script
* changed SOLR_SERVER to SOLR_CORE_URL in the fcrepo env file
* removed redundant SERVICE_ACCOUNT_* entries in the fcrpeo env file

https://issues.umd.edu/browse/LIBFCREPO-698