### PR TITLE
LIBFCREPO-704. Use the non-production LDAP server for Vagrant.

### DIFF
--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -5,6 +5,7 @@ export IP_ADDRESS=192.168.40.10
 export SERVER_NAME=fcrepolocal
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
+export LDAP_SERVER_URL=ldaps://directory.qa.umd.edu
 
 # Apache
 export SSL_CERT_NAME=fcrepolocal


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBFCREPO-704