### PR TITLE
LIBFCREPO-764. Modified Vagrant scripts to use OpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,17 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
    git clone git@bitbucket.org:umd-lib/fedora4-core.git -b develop
    ```
     
-4. Download an [Oracle JDK 8][jdk] tarball (current version is 8u65) and place a
-   copy of it in both the [dist/fcrepo](dist/fcrepo) and [dist/solr](dist/solr)
-   directories.
-
-5. Add `fcrepolocal` and `solrlocal` to your workstation's `/etc/hosts` file:
+4. Add `fcrepolocal` and `solrlocal` to your workstation's `/etc/hosts` file:
 
     ```
     sudo echo "192.168.40.10  fcrepolocal" >> /etc/hosts
     sudo echo "192.168.40.11  solrlocal" >> /etc/hosts
     ```
     
-6. Start up an instance of Postgres from [umd-fcrepo-docker](https://github.com/umd-lib/umd-fcrepo-docker):
+5. Start up an instance of Postgres from [umd-fcrepo-docker](https://github.com/umd-lib/umd-fcrepo-docker):
 
     ```
-    git clone git@github.com:umd-lib/umd-fcrepo-docker.git
+    git clone https://github.com/umd-lib/umd-fcrepo-docker.git
     docker volume create fcrepo-postgres-data
     cd umd-fcrepo-docker/postgres
     docker build -t umd-fcrepo-postgres .
@@ -59,9 +55,13 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
     
     To run the Postgres Docker container in the background, add `-d` to the `docker run`
     command. To automatically delete the container (but not the data) when it is stopped,
-    add `--rm` to the `docker run` command.
+    add `--rm` to the `docker run` command, i.e.:
+    
+    ```
+    docker run -d --rm -p 5432:5432 -v fcrepo-postgres-data:/var/lib/postgresql/data umd-fcrepo-postgres
+    ```
 
-7. Start the Vagrant:
+6. Start the Vagrant:
 
     ```
     cd /apps/git/fcrepo-vagrant

--- a/scripts/fcrepo/jdk.sh
+++ b/scripts/fcrepo/jdk.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-# Oracle JDK
-JDK=$(find /apps/dist -maxdepth 1 -type f -name 'jdk-*.tar.gz' | tail -n1)
-if [ -z "$JDK" ]; then
-    echo >&2 "No JDK found. Please download an Oracle JDK tar.gz and place it in /apps/dist"
-    exit 1
-fi
-echo "Found JDK in $JDK"
-tar xzvf "$JDK" --directory /apps
-# find the newly extracted JDK
-JAVA_HOME=$(find /apps -maxdepth 1 -type d -name 'jdk*' | tail -n1)
+# OpenJDK
+yum install -y java-1.8.0-openjdk-devel
+
+# Find the newly extracted JDK
+JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
 ln -s "$JAVA_HOME" /apps/java
 cat > /etc/profile.d/java.sh <<END
 export JAVA_HOME=$JAVA_HOME

--- a/scripts/solr/jdk.sh
+++ b/scripts/solr/jdk.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-# Oracle JDK
-JDK=$(find /apps/dist -maxdepth 1 -type f -name 'jdk-*.tar.gz' | tail -n1)
-if [ -z "$JDK" ]; then
-    echo >&2 "No JDK found. Please download an Oracle JDK tar.gz and place it in /apps/dist"
-    exit 1
-fi
-echo "Found JDK in $JDK"
-tar xzvf "$JDK" --directory /apps
-# find the newly extracted JDK
-JAVA_HOME=$(find /apps -maxdepth 1 -type d -name 'jdk*' | tail -n1)
+# OpenJDK
+yum install -y java-1.8.0-openjdk-devel
+
+# Find the newly extracted JDK
+JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
 ln -s "$JAVA_HOME" /apps/java
 cat > /etc/profile.d/java.sh <<END
 export JAVA_HOME=$JAVA_HOME


### PR DESCRIPTION
Modified the "scripts/fcrepo/jdk.sh" and "scripts/solr/jdk.sh" scripts
to install the OpenJDV v1.8 using "yum".

This simplifies the setup process by no longer requiring the user to
manually download an Oracle JDK.

https://issues.umd.edu/browse/LIBFCREPO-764