### PR TITLE
LIBFCREPO-766. Removed hard-coded "/apps/git" directory from Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /.vagrant/
 /dist/*/*
 !/dist/*/README.md
+
+# Ignore bootstrap data files
+bootstrap-data.tar.gz
+bootstrap-data/
+
+# Ignore umd-fcrepo-docker
+umd-fcrepo-docker/

--- a/README.md
+++ b/README.md
@@ -36,21 +36,17 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
    git clone git@bitbucket.org:umd-lib/fedora4-core.git -b develop
    ```
     
-4. Download an [Oracle JDK 8][jdk] tarball (current version is 8u65) and place a
-   copy of it in both the [dist/fcrepo](dist/fcrepo) and [dist/solr](dist/solr)
-   directories.
-
-5. Add `fcrepolocal` and `solrlocal` to your workstation's `/etc/hosts` file:
+4. Add `fcrepolocal` and `solrlocal` to your workstation's `/etc/hosts` file:
 
     ```
     sudo echo "192.168.40.10  fcrepolocal" >> /etc/hosts
     sudo echo "192.168.40.11  solrlocal" >> /etc/hosts
     ```
     
-6. Start up an instance of Postgres from [umd-fcrepo-docker](https://github.com/umd-lib/umd-fcrepo-docker):
+5. Start up an instance of Postgres from [umd-fcrepo-docker](https://github.com/umd-lib/umd-fcrepo-docker):
 
     ```
-    git clone git@github.com:umd-lib/umd-fcrepo-docker.git
+    git clone https://github.com/umd-lib/umd-fcrepo-docker.git
     docker volume create fcrepo-postgres-data
     cd umd-fcrepo-docker/postgres
     docker build -t umd-fcrepo-postgres .
@@ -59,9 +55,13 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
     
     To run the Postgres Docker container in the background, add `-d` to the `docker run`
     command. To automatically delete the container (but not the data) when it is stopped,
-    add `--rm` to the `docker run` command.
+    add `--rm` to the `docker run` command, i.e.:
+    
+    ```
+    docker run -d --rm -p 5432:5432 -v fcrepo-postgres-data:/var/lib/postgresql/data umd-fcrepo-postgres
+    ```
 
-7. Start the Vagrant:
+6. Start the Vagrant:
 
     ```
     cd /apps/git/fcrepo-vagrant

--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
 
 ## Setup
 
+**Note:** The fcrepo-vagrant and related repositories must be checked out into
+the "~/git/" directory (i.e., a "git" subdirectory in the user's home
+directory). 
+
 1. Clone this repository:
 
     ```
-    cd /apps/git
+    cd ~/git
     git clone git@github.com:umd-lib/fcrepo-vagrant
     ```
 
-2. Clone [fcrepo-env] into `/apps/git/fcrepo-env`:
+2. Clone [fcrepo-env] into `~/git/fcrepo-env`:
    
     ```
     git clone git@bitbucket.org:umd-lib/fcrepo-env.git
@@ -29,7 +33,7 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
        the missing dependency. The command only finds one missing dependency at a time, and
        so may need to be run multiple times to determine all the dependencies.
     
-3. Clone [fedora4-core] into `/apps/git/fedora4-core`, and check out the `develop`
+3. Clone [fedora4-core] into `~/git/fedora4-core`, and check out the `develop`
    branch:
    
    ```
@@ -64,7 +68,7 @@ running ActiveMQ, Tomcat, Karaf, and Fuseki.
 6. Start the Vagrant:
 
     ```
-    cd /apps/git/fcrepo-vagrant
+    cd ~/git/fcrepo-vagrant
     vagrant up
     ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
     solr.vm.network "private_network", ip: "192.168.40.11"
 
     solr.vm.synced_folder "dist/solr", "/apps/dist"
-    solr.vm.synced_folder "/apps/git/fedora4-core", "/apps/git/fedora4-core"
+    solr.vm.synced_folder "../fedora4-core", "/apps/git/fedora4-core"
 
 
     # Puppet Modules
@@ -58,7 +58,7 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.hostname = 'fcrepolocal'
     fcrepo.vm.network "private_network", ip: "192.168.40.10"
     fcrepo.vm.synced_folder "dist/fcrepo", "/apps/dist"
-    fcrepo.vm.synced_folder "/apps/git/fcrepo-env", "/apps/git/fcrepo-env"
+    fcrepo.vm.synced_folder "../fcrepo-env", "/apps/git/fcrepo-env"
     # share the local Maven repo for rapid testing of Karaf features
     local_maven_repo = "#{ENV['HOME']}/.m2"
     fcrepo.vm.synced_folder local_maven_repo, "/home/vagrant/.m2" if Dir.exist? local_maven_repo

--- a/scripts/fcrepo/jdk.sh
+++ b/scripts/fcrepo/jdk.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-# Oracle JDK
-JDK=$(find /apps/dist -maxdepth 1 -type f -name 'jdk-*.tar.gz' | tail -n1)
-if [ -z "$JDK" ]; then
-    echo >&2 "No JDK found. Please download an Oracle JDK tar.gz and place it in /apps/dist"
-    exit 1
-fi
-echo "Found JDK in $JDK"
-tar xzvf "$JDK" --directory /apps
-# find the newly extracted JDK
-JAVA_HOME=$(find /apps -maxdepth 1 -type d -name 'jdk*' | tail -n1)
+# OpenJDK
+yum install -y java-1.8.0-openjdk-devel
+
+# Find the newly extracted JDK
+JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
 ln -s "$JAVA_HOME" /apps/java
 cat > /etc/profile.d/java.sh <<END
 export JAVA_HOME=$JAVA_HOME

--- a/scripts/solr/jdk.sh
+++ b/scripts/solr/jdk.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-# Oracle JDK
-JDK=$(find /apps/dist -maxdepth 1 -type f -name 'jdk-*.tar.gz' | tail -n1)
-if [ -z "$JDK" ]; then
-    echo >&2 "No JDK found. Please download an Oracle JDK tar.gz and place it in /apps/dist"
-    exit 1
-fi
-echo "Found JDK in $JDK"
-tar xzvf "$JDK" --directory /apps
-# find the newly extracted JDK
-JAVA_HOME=$(find /apps -maxdepth 1 -type d -name 'jdk*' | tail -n1)
+# OpenJDK
+yum install -y java-1.8.0-openjdk-devel
+
+# Find the newly extracted JDK
+JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
 ln -s "$JAVA_HOME" /apps/java
 cat > /etc/profile.d/java.sh <<END
 export JAVA_HOME=$JAVA_HOME


### PR DESCRIPTION
Modified the Vagrantfile to not assume that the repository has been
checked out into the "/apps/git" directory. The Vagrantfile now
uses relative paths to access other repositories needed for generating
the Vagrant machines.

Updated the README.md

Added "bootstrap-data" and "umd-fcrepo-docker" to .gitignore as these
are commonly copied into the "fcrepo-vagrant" directory, but
should not be checked in to the "fcrepo-vagrant" repository.

https://issues.umd.edu/browse/LIBFCREPO-766