### PR TITLE
LIBFCREPO-847. Modified fcrepo-vagrant to use production LDAP server

### DIFF
--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -5,7 +5,7 @@ export IP_ADDRESS=192.168.40.10
 export SERVER_NAME=fcrepolocal
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
-export LDAP_SERVER_URL=ldaps://directory.qa.umd.edu
+export LDAP_SERVER_URL=ldaps://directory.umd.edu
 
 # Apache
 export SSL_CERT_NAME=fcrepolocal


### PR DESCRIPTION
Modified the "files/fcrepo/env" file, changing the "LDAP_SERVER_URL"
to use the production LDAP server, as the QA LDAP server is no longer
available.

https://issues.umd.edu/browse/LIBFCREPO-847