### PR TITLE
LIBFCREPO-887. Removed Fuseki from fcrepo machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Congratulations, you should now have a running fcrepo-vagrant!
 * Application Landing Page: <https://fcrepolocal/>
 * Log in: <https://fcrepolocal/user>
 * Fedora REST interface: <https://fcrepolocal/fcrepo/rest>
-* ActiveMQ Admin Interface: <https://fcrepolocal/activemq/admin>
+* ActiveMQ admin interface: <https://fcrepolocal/activemq/admin>
+* Solr admin interface: <http://localhost:8983/solr/#/>
+* Fuseki admin interface: <http://localhost:3030/>
 
 ### Authentication
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,8 +60,6 @@ Vagrant.configure(2) do |config|
     fcrepo.vm.provision 'shell', inline: '/apps/fedora/setup/install-karaf.sh'
     # install Maven
     fcrepo.vm.provision 'shell', inline: '/apps/fedora/setup/install-maven.sh'
-    # install Fuseki
-    fcrepo.vm.provision 'shell', inline: '/apps/fedora/setup/install-fuseki.sh'
     # configure Apache runtime
     fcrepo.vm.provision 'shell', inline: '/apps/fedora/setup/configure-apache.sh'
     # install pyenv and Python 3

--- a/files/fcrepo/env
+++ b/files/fcrepo/env
@@ -11,7 +11,7 @@ export LDAP_SERVER_URL=ldaps://directory.umd.edu
 export SSL_CERT_NAME=fcrepolocal
 export SSL_KEY_NAME=fcrepolocal
 export TOMCAT_PROXY=https://localhost:9601
-export FUSEKI_PROXY=http://localhost:3030
+export FUSEKI_PROXY=http://192.168.40.1:3030
 export FUSEKI_ADMIN_GROUP=cn=Application_Roles:Libraries:FCREPO:FUSEKI-Administrator,ou=grouper,ou=group,dc=umd,dc=edu
 export ACTIVEMQ_ADMIN_GROUP=cn=Application_Roles:Libraries:FCREPO:ACTIVEMQ-Administrator,ou=grouper,ou=group,dc=umd,dc=edu
 # Tomcat
@@ -29,7 +29,7 @@ export PG_CAMEL_PASSWORD=camel
 # Karaf
 export FCREPO_SERVER=fcrepolocal
 export SOLR_URL=http://192.168.40.1:8983/solr/fedora4
-export FUSEKI_SERVER=fcrepolocal
+export FUSEKI_SERVER=http://192.168.40.1:3030
 export KARAF_FCREPO_LOG_LEVEL=DEBUG
 export KARAF_LOG_RETENTION_DAYS=2
 # ActiveMQ


### PR DESCRIPTION
Use the Fuseki Docker container running on the Vagrant host.

https://issues.umd.edu/browse/LIBFCREPO-887